### PR TITLE
Simplified permissioning by removing language dependency. 

### DIFF
--- a/app/controllers/concerns/populate_strings.rb
+++ b/app/controllers/concerns/populate_strings.rb
@@ -17,15 +17,14 @@ class PopulateStrings
       # prioritize strings that have a user's preferred language
       next if object_strings.pluck(@id_type).include?(object.id)
 
-      languages = object.send(@string_type).pluck(:language)
-      if languages.include?(@language)
-        object.send(@string_type).each do |string|
-          if string.language == @language && @permission_type.nil?
+      languages = object.send(@string_type).pluck(:language) # languages that exist for a string
+      if languages.include?(@language)  # do any of the existing strings match the @language in focus?
+        object.send(@string_type).each do |string| # aka: decks.deck_strings.each |string|
+          if string.language == @language && @permission_type.nil? # string.language == focus language AND we don't need to check your permission because you own it
             object_strings << string
-          elsif @permission_type.nil? == false
-            string.send(@permission_type).each do |permission|
-              object_strings << string if string.language == permission.language && permission.user_id == @user.id
-            end
+          elsif @permission_type.nil? == false && object.send(@permission_type).pluck(:user_id).include?(@user.id)
+            # check if object.permission_types includes your user.id
+            object_strings << string
           end
         end
       else
@@ -39,6 +38,6 @@ class PopulateStrings
         end
       end
     end
-    object_strings.uniq(&:id)
+    object_strings.uniq { |string| string.send(@id_type) }
   end
 end

--- a/app/controllers/decks_controller.rb
+++ b/app/controllers/decks_controller.rb
@@ -105,7 +105,6 @@ class DecksController < ApplicationController
       DeckPermission.create!(
         deck: @deck,
         user: @user,
-        deck_string: @deck.deck_strings.first,
         read_access: true,
         update_access: true,
         clone_access: true
@@ -113,7 +112,6 @@ class DecksController < ApplicationController
       CollectionPermission.create!(
         collection: @deck.collections.first,
         user: @user,
-        collection_string: @deck.collections.first.collection_strings.first,
         read_access: true,
         update_access: true,
         clone_access: true

--- a/app/models/collection_permission.rb
+++ b/app/models/collection_permission.rb
@@ -1,5 +1,4 @@
 class CollectionPermission < ApplicationRecord
   belongs_to :collection
   belongs_to :user
-  belongs_to :collection_string
 end

--- a/app/models/collection_string.rb
+++ b/app/models/collection_string.rb
@@ -1,7 +1,6 @@
 class CollectionString < ApplicationRecord
   belongs_to :collection
   belongs_to :user
-  has_many :collection_permissions
 
   validates :collection, :language, :title, presence: true
 end

--- a/app/models/deck_permission.rb
+++ b/app/models/deck_permission.rb
@@ -1,5 +1,4 @@
 class DeckPermission < ApplicationRecord
   belongs_to :deck
   belongs_to :user
-  belongs_to :deck_string
 end

--- a/app/models/deck_string.rb
+++ b/app/models/deck_string.rb
@@ -1,7 +1,6 @@
 class DeckString < ApplicationRecord
   belongs_to :deck
   belongs_to :user
-  has_many :deck_permissions
   accepts_nested_attributes_for :deck
 
   validates :deck, :language, :title, presence: true

--- a/app/models/question_set_permission.rb
+++ b/app/models/question_set_permission.rb
@@ -1,5 +1,4 @@
 class QuestionSetPermission < ApplicationRecord
   belongs_to :user
   belongs_to :question_set
-  belongs_to :question_set_string
 end

--- a/app/models/question_set_string.rb
+++ b/app/models/question_set_string.rb
@@ -1,7 +1,6 @@
 class QuestionSetString < ApplicationRecord
   belongs_to :question_set
   belongs_to :user
-  has_many :question_set_permissions
 
   validates :language, :title, presence: true
 end

--- a/app/models/tag_set_permission.rb
+++ b/app/models/tag_set_permission.rb
@@ -1,5 +1,4 @@
 class TagSetPermission < ApplicationRecord
   belongs_to :tag_set
   belongs_to :user
-  belongs_to :tag_set_string
 end

--- a/app/models/tag_set_string.rb
+++ b/app/models/tag_set_string.rb
@@ -1,7 +1,6 @@
 class TagSetString < ApplicationRecord
   belongs_to :tag_set
   belongs_to :user
-  has_many :tag_set_permissions
 
   validates :title, :language, presence: true
 end

--- a/db/migrate/20200609123812_create_deck_permissions.rb
+++ b/db/migrate/20200609123812_create_deck_permissions.rb
@@ -1,13 +1,11 @@
 class CreateDeckPermissions < ActiveRecord::Migration[6.0]
   def change
     create_table :deck_permissions do |t|
-      t.string :language
       t.boolean :read_access, default: false
       t.boolean :update_access, default: false
       t.boolean :clone_access, default: false
       t.references :deck, null: false, foreign_key: true
       t.references :user, null: false, foreign_key: true
-      t.references :deck_string, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20200611181701_create_collection_permissions.rb
+++ b/db/migrate/20200611181701_create_collection_permissions.rb
@@ -1,13 +1,11 @@
 class CreateCollectionPermissions < ActiveRecord::Migration[6.0]
   def change
     create_table :collection_permissions do |t|
-      t.string :language
       t.boolean :read_access, default: false
       t.boolean :update_access, default: false
       t.boolean :clone_access, default: false
       t.references :user, null: false, foreign_key: true
       t.references :collection, null: false, foreign_key: true
-      t.references :collection_string, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20200614113137_create_tag_set_permissions.rb
+++ b/db/migrate/20200614113137_create_tag_set_permissions.rb
@@ -1,12 +1,10 @@
 class CreateTagSetPermissions < ActiveRecord::Migration[6.0]
   def change
     create_table :tag_set_permissions do |t|
-      t.string :language
       t.boolean :read_access, default: false
       t.boolean :update_access, default: false
       t.references :tag_set, null: false, foreign_key: true
       t.references :user, null: false, foreign_key: true
-      t.references :tag_set_string, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20200615212133_create_question_set_permissions.rb
+++ b/db/migrate/20200615212133_create_question_set_permissions.rb
@@ -1,13 +1,11 @@
 class CreateQuestionSetPermissions < ActiveRecord::Migration[6.0]
   def change
     create_table :question_set_permissions do |t|
-      t.string :language
       t.boolean :read_access, default: false
       t.boolean :update_access, default: false
       t.boolean :clone_access, default: false
       t.references :user, null: false, foreign_key: true
       t.references :question_set, null: false, foreign_key: true
-      t.references :question_set_string, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -85,17 +85,14 @@ ActiveRecord::Schema.define(version: 2020_06_22_082128) do
   end
 
   create_table "collection_permissions", force: :cascade do |t|
-    t.string "language"
     t.boolean "read_access", default: false
     t.boolean "update_access", default: false
     t.boolean "clone_access", default: false
     t.bigint "user_id", null: false
     t.bigint "collection_id", null: false
-    t.bigint "collection_string_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["collection_id"], name: "index_collection_permissions_on_collection_id"
-    t.index ["collection_string_id"], name: "index_collection_permissions_on_collection_string_id"
     t.index ["user_id"], name: "index_collection_permissions_on_user_id"
   end
 
@@ -131,17 +128,14 @@ ActiveRecord::Schema.define(version: 2020_06_22_082128) do
   end
 
   create_table "deck_permissions", force: :cascade do |t|
-    t.string "language"
     t.boolean "read_access", default: false
     t.boolean "update_access", default: false
     t.boolean "clone_access", default: false
     t.bigint "deck_id", null: false
     t.bigint "user_id", null: false
-    t.bigint "deck_string_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["deck_id"], name: "index_deck_permissions_on_deck_id"
-    t.index ["deck_string_id"], name: "index_deck_permissions_on_deck_string_id"
     t.index ["user_id"], name: "index_deck_permissions_on_user_id"
   end
 
@@ -185,17 +179,14 @@ ActiveRecord::Schema.define(version: 2020_06_22_082128) do
   end
 
   create_table "question_set_permissions", force: :cascade do |t|
-    t.string "language"
     t.boolean "read_access", default: false
     t.boolean "update_access", default: false
     t.boolean "clone_access", default: false
     t.bigint "user_id", null: false
     t.bigint "question_set_id", null: false
-    t.bigint "question_set_string_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["question_set_id"], name: "index_question_set_permissions_on_question_set_id"
-    t.index ["question_set_string_id"], name: "index_question_set_permissions_on_question_set_string_id"
     t.index ["user_id"], name: "index_question_set_permissions_on_user_id"
   end
 
@@ -245,16 +236,13 @@ ActiveRecord::Schema.define(version: 2020_06_22_082128) do
   end
 
   create_table "tag_set_permissions", force: :cascade do |t|
-    t.string "language"
     t.boolean "read_access", default: false
     t.boolean "update_access", default: false
     t.bigint "tag_set_id", null: false
     t.bigint "user_id", null: false
-    t.bigint "tag_set_string_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["tag_set_id"], name: "index_tag_set_permissions_on_tag_set_id"
-    t.index ["tag_set_string_id"], name: "index_tag_set_permissions_on_tag_set_string_id"
     t.index ["user_id"], name: "index_tag_set_permissions_on_user_id"
   end
 
@@ -357,7 +345,6 @@ ActiveRecord::Schema.define(version: 2020_06_22_082128) do
   add_foreign_key "cards", "decks"
   add_foreign_key "collection_cards", "cards"
   add_foreign_key "collection_cards", "collections"
-  add_foreign_key "collection_permissions", "collection_strings"
   add_foreign_key "collection_permissions", "collections"
   add_foreign_key "collection_permissions", "users"
   add_foreign_key "collection_strings", "collections"
@@ -366,7 +353,6 @@ ActiveRecord::Schema.define(version: 2020_06_22_082128) do
   add_foreign_key "collection_tags", "tag_sets"
   add_foreign_key "collections", "decks"
   add_foreign_key "collections", "users"
-  add_foreign_key "deck_permissions", "deck_strings"
   add_foreign_key "deck_permissions", "decks"
   add_foreign_key "deck_permissions", "users"
   add_foreign_key "deck_strings", "decks"
@@ -375,7 +361,6 @@ ActiveRecord::Schema.define(version: 2020_06_22_082128) do
   add_foreign_key "decks", "users"
   add_foreign_key "memberships", "user_groups"
   add_foreign_key "memberships", "users"
-  add_foreign_key "question_set_permissions", "question_set_strings"
   add_foreign_key "question_set_permissions", "question_sets"
   add_foreign_key "question_set_permissions", "users"
   add_foreign_key "question_set_strings", "question_sets"
@@ -385,7 +370,6 @@ ActiveRecord::Schema.define(version: 2020_06_22_082128) do
   add_foreign_key "question_strings", "questions"
   add_foreign_key "tag_relations", "tag_sets"
   add_foreign_key "tag_relations", "tags"
-  add_foreign_key "tag_set_permissions", "tag_set_strings"
   add_foreign_key "tag_set_permissions", "tag_sets"
   add_foreign_key "tag_set_permissions", "users"
   add_foreign_key "tag_set_strings", "tag_sets"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,28 +34,29 @@ category_list.each do |key, array|
 end
 
 
-def generate_permissions(value, string_hash, user, deck, collection, question_set, tag_set = nil, user_group = nil, languages= [:en, :fr])
+def generate_permissions(**objects)
   users = []
-  users << user
-  languages.each do |language|
+  users << objects[:user]
+  n = 0
+  while n < 3
     other_user_chosen = false
     while other_user_chosen == false
       other_user = User.all.sample
       other_user_chosen = true if users.include?(other_user) == false
     end
     users << other_user
-    deck_hash = { user: other_user, deck: deck, deck_string: string_hash[language][0], language: language, read_access: true }
-    collection_hash = { user: other_user, collection: collection, collection_string: string_hash[language][1], language: language, read_access: true }
-    question_set_hash = { user: other_user, question_set: question_set, question_set_string: string_hash[language][2], language: language, read_access: true }
-    tag_set_hash = { user: other_user, tag_set: tag_set, tag_set_string: string_hash[language][3], language: language, read_access: true } unless tag_set.nil?
-    user_group_hash = { user: other_user, user_group: user_group, user_label: "friend #{other_user.id}", owner_id: user.id, email_contact: other_user.email, read_access: true } unless user_group.nil?
-    if value == 'update'
+    deck_hash = { user: other_user, deck: objects[:deck], read_access: true }
+    collection_hash = { user: other_user, collection: objects[:collection], read_access: true }
+    question_set_hash = { user: other_user, question_set: objects[:question_set], read_access: true }
+    tag_set_hash = { user: other_user, tag_set: objects[:tag_set], read_access: true } unless n == 2
+    user_group_hash = { user: other_user, user_group: objects[:user_group], user_label: "friend #{other_user.id}", owner_id: objects[:user].id, email_contact: other_user.email, read_access: true } unless n == 2
+    if n == 1
       deck_hash[:update_access] = true
       collection_hash[:update_access] = true
       question_set_hash[:update_access] = true
       tag_set_hash[:update_access] = true
       user_group_hash[:update_access] = true
-    elsif value == 'clone'
+    elsif n == 2
       deck_hash[:clone_access] = true
       collection_hash[:clone_access] = true
       question_set_hash[:clone_access] = true
@@ -64,16 +65,16 @@ def generate_permissions(value, string_hash, user, deck, collection, question_se
     permission = false
     until permission
       deck_random = Deck.all.sample
-      if deck_random.user != user
+      if deck_random.user != objects[:user]
         DeckPermission.create!(deck_hash)
         CollectionPermission.create!(collection_hash)
         QuestionSetPermission.create!(question_set_hash)
-        TagSetPermission.create!(tag_set_hash) unless tag_set.nil?
-        Membership.create!(user_group_hash) unless user_group.nil?
-        puts "#{value} access given to #{deck_random}"
+        TagSetPermission.create!(tag_set_hash) unless n == 2
+        Membership.create!(user_group_hash) unless n == 2
         permission = true
       end
     end
+    n += 1
   end
 end
 
@@ -110,18 +111,27 @@ languages = [:en, :fr]
     string_hash = create_strings(user, deck, collection, question_set, tag_set, x)
     x += 1
     user_group = UserGroup.create!(user: user, name: Faker::Book.title)
-    DeckPermission.create!(user: user, deck: deck, deck_string: string_hash[language][0], language: language, read_access: true, update_access: true, clone_access: true)
-    CollectionPermission.create!(user: user, collection: collection, collection_string: string_hash[language][1], language: language, read_access: true, update_access: true, clone_access: true)
-    QuestionSetPermission.create!(user: user, question_set: question_set, question_set_string: string_hash[language][2], language: language, read_access: true, update_access: true, clone_access: true)
-    TagSetPermission.create!(user: user, tag_set: tag_set, tag_set_string: string_hash[language][3], language: language, read_access: true, update_access: true)
+
+    DeckPermission.create!(user: user, deck: deck, read_access: true, update_access: true, clone_access: true)
+    CollectionPermission.create!(user: user, collection: collection, read_access: true, update_access: true, clone_access: true)
+    QuestionSetPermission.create!(user: user, question_set: question_set, read_access: true, update_access: true, clone_access: true)
+    TagSetPermission.create!(user: user, tag_set: tag_set, read_access: true, update_access: true)
     Membership.create!(user: user, user_group: user_group, user_label: 'Group Owner', status: 'Managing Group', owner_id: user.id, email_contact: email, read_access: true, update_access: true)
     if User.count > 8
-      generate_permissions('read', string_hash, user, deck, collection, question_set, tag_set, user_group)
-      generate_permissions('update', string_hash, user, deck, collection, question_set, tag_set, user_group)
-      generate_permissions('clone', string_hash, user, deck, collection, question_set)
+      object_hash = {
+        user: user,
+        deck: deck,
+        collection: collection,
+        question_set: question_set,
+        tag_set: tag_set,
+        user_group: user_group
+      }
+      generate_permissions(object_hash)
     end
   end
 end
+
+puts 'finished seed!'
 
 
 


### PR DESCRIPTION
- Removed string-permission association in models as access will depend on the parent
- Seed revised to account for permission changes
- References to strings in permission migrations removed
- Populate strings now checks whether an object (deck, collection...) permission exists for the user. If so they have access to all data for that object.
- Added a few comments to user group show and populate strings concern class